### PR TITLE
High Res QR Codes

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -4366,9 +4366,13 @@
 					var height = qrcode.getModuleCount() * sizeMultiplier;
 					// create canvas element
 					var canvas = document.createElement('canvas');
-					canvas.width = width;
-					canvas.height = height;
+					var scale = 10.0;
+					canvas.width = width * scale;
+					canvas.height = height * scale;
+					canvas.style.width = width + 'px';
+					canvas.style.height = height + 'px';
 					var ctx = canvas.getContext('2d');
+					ctx.scale(scale, scale);
 					// compute tileW/tileH based on width/height
 					var tileW = width / qrcode.getModuleCount();
 					var tileH = height / qrcode.getModuleCount();


### PR DESCRIPTION
I've been annoyed by the fact that the QR codes that bitaddress.org generates are only screen resolution, which results in thin black lines between the pixels when QR codes are generated by Chrome then printed, and thin white lines between the pixels when QR codes are generated by safari. The patch I've made makes the canvas 10X larger but the same screen width and height, resulting in a beautiful display at print resolutions. You can see both the problem and its solution in my patch by saving the "Bitcoin Banknotes" to PDF and viewing the result at higher magnification.
