### PR TITLE
Hide #culturemenu on @media print

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -4089,6 +4089,7 @@
 		@media print
 		{
 			#main { width: auto; }
+			#culturemenu { display: none; }
 			#paperarea .keyarea:first-child { border-top: 2px solid green; }
 			#paperarea .keyarea.art:first-child { border: 0; }
 			.pagebreak { height: 1px; }


### PR DESCRIPTION
The language selection header was getting printed along with the paper wallets.

Thanks for the awesome code and service.
