### PR TITLE
Fix bug with "Addresses per page" == 1

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -6466,7 +6466,7 @@
 					}
 					if (paperArea.innerHTML != "") {
 						// page break
-						if (i % pageBreakAt == 1 && ninja.wallets.paperwallet.count >= pageBreakAt) {
+						if ((i-1) % pageBreakAt == 0 && i >= pageBreakAt) {
 							var pBreak = document.createElement("div");
 							pBreak.setAttribute("class", "pagebreak");
 							document.getElementById("paperkeyarea").appendChild(pBreak);


### PR DESCRIPTION
It was effectively "don't insert any pagebreaks" because the modulus
condition could never be true.

I tested with several combinations of number of addresses and addresses per page, but let me know if something looks wrong.
