### PR TITLE
Two column layout for bulk paper wallets

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -5682,7 +5682,7 @@ Bitcoin.Util = {
 .keyarea { font-family: Courier New; height: 110px; text-align: left; position: relative; padding: 5px; }
 .keyarea .public { float: left; }
 .keyarea .pubaddress { display: inline-block; height: 40px; padding: 0 0 0 10px; float: left; }
-.keyarea .privwif { margin: 0;  float: right; text-align: right; padding: 0 20px 0 0; position: relative; }
+.keyarea .privwif { margin: 0;  float: right; text-align: right; padding: 0 20px 0 0; position: relative; word-break: break-word; width: 40%; }
 .keyarea .label { text-decoration: underline; }
 .keyarea .output { display: block; }
 .keyarea .qrcode_public { display: inline-block; float: left; }


### PR DESCRIPTION
Hi,

I'd like to generate bulk wallets in such a way that I can cut away the public keys and give people the private keys without them knowing the public keys. Obviously this only makes sense with BIP 0038 encryption. The logic being that a potential thief would then not know the balance, and thus not know if it was worth their while trying to break the encryption or not.

(My long term plan would be to have one wallet with a weak password and a token amount as a sentinel, if this wallet is stolen I'll know the others are vulnerable - but this is probably beyond the scope of bitaddress.org).

I'm not a CSS expert and I concede that the mid-word break is a little ugly, but it does the job. Happy to make ammendments though - let me know!
