### PR TITLE
Use window.crypto.getRandomValues for added OS-supplied randomness

### DIFF
--- a/src/securerandom.js
+++ b/src/securerandom.js
@@ -29,6 +29,15 @@
 	// ba: byte array
 	sr.prototype.nextBytes = function (ba) {
 		var i;
+		if (window.crypto && window.crypto.getRandomValues && window.Uint8Array) {
+			try {
+				var rvBytes = new Uint8Array(ba.length);
+				window.crypto.getRandomValues(rvBytes);
+				for (i = 0; i < ba.length; ++i)
+					ba[i] = sr.getByte() ^ rvBytes[i];
+				return;
+			} catch(e) {}
+		}
 		for (i = 0; i < ba.length; ++i) ba[i] = sr.getByte();
 	};
 


### PR DESCRIPTION
If `window.crypto.getRandomValues` is present, then the output of SecureRandom.nextBytes is XORed against its result. All major browsers (IE starting at 11) support getRandomValues.

I do this instead of seeding the Arcfour PRNG with getRandomValues because I'm not sure how much I trust Arcfour as an RNG, or the implementation. RC4 has a few known issues as an encryption algorithm, and while I'm not sure if any of those issues translate into issues with it as a PRNG, I'd rather not bet bitcoins on it.

XORing the output of two random unrelated bytestreams should be at least as random as the more random of the two. Even if you trust Arcfour over getRandomValues, this shouldn't decrease randomness at all.

For what it's worth, I believe Linux integrates CPU random number generators (Intel's RdRand) in a similar way in its random number generator.

The try-catch block is because getRandomValues is [documented](https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues) as being able to throw QuotaExceededError. If an exception happens, then Arcfour is used alone as before.
