### PR TITLE
Seed mouse movements as 16-bit numbers.

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -1562,6 +1562,12 @@ if (typeof Crypto == "undefined" || !Crypto.util) {
 		sr.seedInt8((x >> 24));
 	}
 
+	// Mix in a 16-bit integer into the pool
+	sr.seedInt16 = function (x) {
+		sr.seedInt8(x);
+		sr.seedInt8((x >> 8));
+	}
+
 	// Mix in a 8-bit integer into the pool
 	sr.seedInt8 = function (x) {
 		sr.pool[sr.pptr++] ^= x & 255;
@@ -6641,7 +6647,7 @@ ninja.seeder = {
 	// number of mouse movements to wait for
 	seedLimit: (function () {
 		var num = Crypto.util.randomBytes(12)[11];
-		return 100 + Math.floor(num);
+		return 200 + Math.floor(num);
 	})(),
 
 	seedCount: 0, // counter
@@ -6653,7 +6659,7 @@ ninja.seeder = {
 		// seed a bunch (minimum seedLimit) of times based on mouse moves
 		SecureRandom.seedTime();
 		// seed mouse position X and Y
-		if (evt) SecureRandom.seedInt((evt.clientX * evt.clientY));
+		if (evt) SecureRandom.seedInt16((evt.clientX * evt.clientY));
 
 		ninja.seeder.seedCount++;
 		// seeding is over now we generate and display the address

--- a/src/ninja.misc.js
+++ b/src/ninja.misc.js
@@ -2,7 +2,7 @@ ninja.seeder = {
 	// number of mouse movements to wait for
 	seedLimit: (function () {
 		var num = Crypto.util.randomBytes(12)[11];
-		return 100 + Math.floor(num);
+		return 200 + Math.floor(num);
 	})(),
 
 	seedCount: 0, // counter
@@ -14,7 +14,7 @@ ninja.seeder = {
 		// seed a bunch (minimum seedLimit) of times based on mouse moves
 		SecureRandom.seedTime();
 		// seed mouse position X and Y
-		if (evt) SecureRandom.seedInt((evt.clientX * evt.clientY));
+		if (evt) SecureRandom.seedInt16((evt.clientX * evt.clientY));
 
 		ninja.seeder.seedCount++;
 		// seeding is over now we generate and display the address

--- a/src/securerandom.js
+++ b/src/securerandom.js
@@ -75,6 +75,12 @@
 		sr.seedInt8((x >> 24));
 	}
 
+	// Mix in a 16-bit integer into the pool
+	sr.seedInt16 = function (x) {
+		sr.seedInt8(x);
+		sr.seedInt8((x >> 8));
+	}
+
 	// Mix in a 8-bit integer into the pool
 	sr.seedInt8 = function (x) {
 		sr.pool[sr.pptr++] ^= x & 255;


### PR DESCRIPTION
Basic resolution is 1024x768, which is 786432 - 19 bit. When you seed using 32 bit, 13 upper bits never get filled. When you seed using 16 bit and resolution is at least 341x192 every bits get filled even when you moving at x>341 and y>192 - upper bits not used.
