### PR TITLE
Ignore node_modules sub-directory in git.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
I'm not Grunt expert, but my  environment have this subdirectory. If this is standard, good idea is to ignore this directory in git.
