### PR TITLE
Removes the trimming that occurs on user input passphrases for both BIP3...

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -8168,9 +8168,9 @@ ninja.wallets.brainwallet = {
 	minPassphraseLength: 15,
 
 	view: function () {
-		var key = document.getElementById("brainpassphrase").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+		var key = document.getElementById("brainpassphrase").value.toString()
 		document.getElementById("brainpassphrase").value = key;
-		var keyConfirm = document.getElementById("brainpassphraseconfirm").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+		var keyConfirm = document.getElementById("brainpassphraseconfirm").value.toString()
 		document.getElementById("brainpassphraseconfirm").value = keyConfirm;
 
 		if (key == keyConfirm || document.getElementById("brainpassphraseshow").checked) {
@@ -8373,7 +8373,7 @@ ninja.wallets.detailwallet = {
 				document.getElementById("detailprivkeypassphrase").focus();
 				return;
 			}
-			var passphrase = document.getElementById("detailprivkeypassphrase").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+			var passphrase = document.getElementById("detailprivkeypassphrase").value.toString()
 			if (passphrase == "") {
 				alert(ninja.translator.get("bip38alertpassphraserequired"));
 				return;

--- a/src/ninja.brainwallet.js
+++ b/src/ninja.brainwallet.js
@@ -12,9 +12,9 @@ ninja.wallets.brainwallet = {
 	minPassphraseLength: 15,
 
 	view: function () {
-		var key = document.getElementById("brainpassphrase").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+		var key = document.getElementById("brainpassphrase").value.toString()
 		document.getElementById("brainpassphrase").value = key;
-		var keyConfirm = document.getElementById("brainpassphraseconfirm").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+		var keyConfirm = document.getElementById("brainpassphraseconfirm").value.toString()
 		document.getElementById("brainpassphraseconfirm").value = keyConfirm;
 
 		if (key == keyConfirm || document.getElementById("brainpassphraseshow").checked) {

--- a/src/ninja.detailwallet.js
+++ b/src/ninja.detailwallet.js
@@ -37,7 +37,7 @@ ninja.wallets.detailwallet = {
 				document.getElementById("detailprivkeypassphrase").focus();
 				return;
 			}
-			var passphrase = document.getElementById("detailprivkeypassphrase").value.toString().replace(/^\s+|\s+$/g, ""); // trim white space
+			var passphrase = document.getElementById("detailprivkeypassphrase").value.toString()
 			if (passphrase == "") {
 				alert(ninja.translator.get("bip38alertpassphraserequired"));
 				return;


### PR DESCRIPTION
Issue is that the BIP38 encryption passphrase input on the 'Paper Wallet' tab is NOT trimmed, but subsequent passphrase input on the 'Wallet Details' tab is trimmed.  Thus the user is able to input leading or trailing spaces to encrypt the private key, but cannot include those leading and/or trailing spaces to decrypt the private key.

An alternate solution would be to also trim the input on the encryption side, however that solution unnecessarily restricts what the user is able to input as a passphrase.  Also, it's possible that a user has already created a BIP38 encrypted private key with leading/trailing spaces and would not be able to decrypt that key on the site as-is or with the alternate solution.

I also removed the trimming that occurs on brain wallet pass phrases for the same reasons.

Note: This is my first contribution to a open source project, so I'm not exactly sure how to go about contributing.  If I have made a technical or proprietary snafu, please forgive me.