### PR TITLE
Increased the HTML height to allow for greater seed value entropy

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -6314,6 +6314,7 @@ hr { margin: 20px 0; border-top: 2px dashed #008000; }
 .keyarea .qrcode_private { display: inline-block; position: relative; top: 28px; float: right; }
 .pubkeyhex { word-wrap: break-word; }
 body { font-family: Arial; }
+body, html { height: 99%; }
 .faqs ol { padding: 0 0 0 25px; }
 .faqs li { padding: 3px 0; }
 .question { padding: 10px 15px; text-align: left; cursor: pointer; }

--- a/src/main.css
+++ b/src/main.css
@@ -16,6 +16,7 @@ hr { margin: 20px 0; border-top: 2px dashed #008000; }
 .keyarea .qrcode_private { display: inline-block; position: relative; top: 28px; float: right; }
 .pubkeyhex { word-wrap: break-word; }
 body { font-family: Arial; }
+body, html { height: 99%; }
 .faqs ol { padding: 0 0 0 25px; }
 .faqs li { padding: 3px 0; }
 .question { padding: 10px 15px; text-align: left; cursor: pointer; }


### PR DESCRIPTION
This fixes the "small" height entropy window, because the JS doesn't detect the mouse points outside of the `body` tag's content height.

So if the page content is only 50% of the screen's height, you can only use 50% of the available height entropy to generate random seed points.

This commit makes the `html` and `body` tags have a set height of `100%` and fixes this minor issue.

---

This is a fixed re-push of pull request #69.
