### PR TITLE
Ask user to confirm making new wallet

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -9591,26 +9591,44 @@ ninja.wallets.singlewallet = {
 
 	// generate bitcoin address and private key and update information in the HTML
 	generateNewAddressAndKey: function () {
-		try {
-			var key = new Bitcoin.ECKey(false);
-			var bitcoinAddress = key.getBitcoinAddress();
-			var privateKeyWif = key.getBitcoinWalletImportFormat();
-			document.getElementById("btcaddress").innerHTML = bitcoinAddress;
-			document.getElementById("btcprivwif").innerHTML = privateKeyWif;
-			var keyValuePair = {
-				"qrcode_public": bitcoinAddress,
-				"qrcode_private": privateKeyWif
-			};
-			ninja.qrCode.showQrCode(keyValuePair, 4);
+		this.generate = function () {
+			if ( document.getElementById("qrcode_private").innerHTML.length && window.sessionStorage ) {
+				window.sessionStorage.previous_address = document.getElementById("btcaddress").innerHTML
+				window.sessionStorage.previous_private_key = document.getElementById("btcprivwif").innerHTML
+			}
+
+			try {
+				var key = new Bitcoin.ECKey(false);
+				var bitcoinAddress = key.getBitcoinAddress();
+				var privateKeyWif = key.getBitcoinWalletImportFormat();
+				document.getElementById("btcaddress").innerHTML = bitcoinAddress;
+				document.getElementById("btcprivwif").innerHTML = privateKeyWif;
+
+				window.sessionStorage.newest_address = bitcoinAddress
+				window.sessionStorage.newest_private_key = privateKeyWif
+
+				var keyValuePair = {
+					"qrcode_public": bitcoinAddress,
+					"qrcode_private": privateKeyWif
+				};
+				ninja.qrCode.showQrCode(keyValuePair, 4);
+			}
+			catch (e) {
+				// browser does not have sufficient JavaScript support to generate a bitcoin address
+				alert(e);
+				document.getElementById("btcaddress").innerHTML = "error";
+				document.getElementById("btcprivwif").innerHTML = "error";
+				document.getElementById("qrcode_public").innerHTML = "";
+				document.getElementById("qrcode_private").innerHTML = "";
+			}
+
 		}
-		catch (e) {
-			// browser does not have sufficient JavaScript support to generate a bitcoin address
-			alert(e);
-			document.getElementById("btcaddress").innerHTML = "error";
-			document.getElementById("btcprivwif").innerHTML = "error";
-			document.getElementById("qrcode_public").innerHTML = "";
-			document.getElementById("qrcode_private").innerHTML = "";
-		}
+
+		if ( document.getElementById("qrcode_private").innerHTML.length ) {
+			if ( confirm( "WARNING: This will permanently erase the current private key that is on the screen. If you have not saved this private key, press cancel now!" ) ) {
+				return this.generate()
+			} else return
+		} else return this.generate()
 	}
 };
 	</script>

--- a/src/ninja.singlewallet.js
+++ b/src/ninja.singlewallet.js
@@ -16,25 +16,43 @@ ninja.wallets.singlewallet = {
 
 	// generate bitcoin address and private key and update information in the HTML
 	generateNewAddressAndKey: function () {
-		try {
-			var key = new Bitcoin.ECKey(false);
-			var bitcoinAddress = key.getBitcoinAddress();
-			var privateKeyWif = key.getBitcoinWalletImportFormat();
-			document.getElementById("btcaddress").innerHTML = bitcoinAddress;
-			document.getElementById("btcprivwif").innerHTML = privateKeyWif;
-			var keyValuePair = {
-				"qrcode_public": bitcoinAddress,
-				"qrcode_private": privateKeyWif
-			};
-			ninja.qrCode.showQrCode(keyValuePair, 4);
+		this.generate = function () {
+			if ( document.getElementById("qrcode_private").innerHTML.length && window.sessionStorage ) {
+				window.sessionStorage.previous_address = document.getElementById("btcaddress").innerHTML
+				window.sessionStorage.previous_private_key = document.getElementById("btcprivwif").innerHTML
+			}
+
+			try {
+				var key = new Bitcoin.ECKey(false);
+				var bitcoinAddress = key.getBitcoinAddress();
+				var privateKeyWif = key.getBitcoinWalletImportFormat();
+				document.getElementById("btcaddress").innerHTML = bitcoinAddress;
+				document.getElementById("btcprivwif").innerHTML = privateKeyWif;
+
+				window.sessionStorage.newest_address = bitcoinAddress
+				window.sessionStorage.newest_private_key = privateKeyWif
+
+				var keyValuePair = {
+					"qrcode_public": bitcoinAddress,
+					"qrcode_private": privateKeyWif
+				};
+				ninja.qrCode.showQrCode(keyValuePair, 4);
+			}
+			catch (e) {
+				// browser does not have sufficient JavaScript support to generate a bitcoin address
+				alert(e);
+				document.getElementById("btcaddress").innerHTML = "error";
+				document.getElementById("btcprivwif").innerHTML = "error";
+				document.getElementById("qrcode_public").innerHTML = "";
+				document.getElementById("qrcode_private").innerHTML = "";
+			}
+
 		}
-		catch (e) {
-			// browser does not have sufficient JavaScript support to generate a bitcoin address
-			alert(e);
-			document.getElementById("btcaddress").innerHTML = "error";
-			document.getElementById("btcprivwif").innerHTML = "error";
-			document.getElementById("qrcode_public").innerHTML = "";
-			document.getElementById("qrcode_private").innerHTML = "";
-		}
+
+		if ( document.getElementById("qrcode_private").innerHTML.length ) {
+			if ( confirm( "WARNING: This will permanently erase the current private key that is on the screen. If you have not saved this private key, press cancel now!" ) ) {
+				return this.generate()
+			} else return
+		} else return this.generate()
 	}
 };


### PR DESCRIPTION
Warns users before they generate a new single wallet, which will erase
the old one. Also stores the addresses and keys in sessionStorage in
case it needs to be recovered.