### PR TITLE
Allow more than 99 dice to be rolled

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -5726,7 +5726,7 @@ Bitcoin.ECKey = (function () {
 			}
 			
 			if (ECKey.isBase6Format(input)) {
-				this.priv = new BigInteger(input, 6);
+				this.priv = new BigInteger(input.replace(/6/g, '0'), 6).and(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));
 			} else if (bytes == null || bytes.length != 32) {
 				this.priv = null;
 			} else {
@@ -5947,10 +5947,10 @@ Bitcoin.ECKey = (function () {
 		return (/^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789=+\/]{44}$/.test(key));
 	};
 
-	// 99 characters, 1=1, if using dice convert 6 to 0
+	// 99 or more characters, 1=1, if using dice convert 6 to 0
 	ECKey.isBase6Format = function (key) {
 		key = key.toString();
-		return (/^[012345]{99}$/.test(key));
+		return (/^[0-6]{99,}$/.test(key));
 	};
 
 	// 22, 26 or 30 characters, always starts with an 'S'
@@ -6972,7 +6972,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 						<span class="output" id="detailprivmini"></span>
 					</div>
 					<div class="item" style="display: none;" id="detailb6">
-						<span class="label" id="detaillabelprivb6">Private Key Base6 Format (99 characters [0-5]):</span>
+						<span class="label" id="detaillabelprivb6">Private Key Base6 Format (99 or more characters [0-5]):</span>
 						<span class="output" id="detailprivb6"></span>
 					</div>
 					<div class="item" style="display: none;" id="detailbip38">
@@ -6987,7 +6987,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 							<span id="detaillabelq1">How do I make a wallet using dice? What is B6?</span>
 							<div id="detaile1" class="more"></div>
 						</div>
-						<div id="detaila1" class="answer">An important part of creating a Bitcoin wallet is ensuring the random numbers used to create the wallet are truly random. Physical randomness is better than computer generated pseudo-randomness. The easiest way to generate physical randomness is with dice. To create a Bitcoin private key you only need one six sided die which you roll 99 times. Stopping each time to record the value of the die. When recording the values follow these rules: 1=1, 2=2, 3=3, 4=4, 5=5, 6=0. By doing this you are recording the big random number, your private key, in B6 or base 6 format. You can then enter the 99 character base 6 private key into the text field above and click View Details. You will then see the Bitcoin address associated with your private key. You should also make note of your private key in WIF format since it is more widely used.</div>
+						<div id="detaila1" class="answer">An important part of creating a Bitcoin wallet is ensuring the random numbers used to create the wallet are truly random. Physical randomness is better than computer generated pseudo-randomness. The easiest way to generate physical randomness is with dice. To create a Bitcoin private key you only need one six sided die which you roll 99 or more times. Stopping each time to record the value of the die. Each 6 will automatically be replaced by a 0. By doing this you are recording the big random number, your private key, in B6 or base 6 format. You can then enter the base 6 private key into the text field above and click View Details. You will then see the Bitcoin address associated with your private key. You should also make note of your private key in WIF format since it is more widely used.</div>
 					</div>
 				</div>
 			</div>
@@ -10433,7 +10433,7 @@ ninja.wallets.vanitywallet = {
 		checkAndShowBase6: function (key) {
 			if (Bitcoin.ECKey.isBase6Format(key)) {
 				// show Private Key Base6 Format
-				document.getElementById("detailprivb6").innerHTML = key;
+				document.getElementById("detailprivb6").innerHTML = key.replace(/6/g, '0');
 				document.getElementById("detailb6").style.display = "block";
 			}
 		},

--- a/src/bitaddress-ui.html
+++ b/src/bitaddress-ui.html
@@ -456,7 +456,7 @@
 						<span class="output" id="detailprivmini"></span>
 					</div>
 					<div class="item" style="display: none;" id="detailb6">
-						<span class="label" id="detaillabelprivb6">Private Key Base6 Format (99 characters [0-5]):</span>
+						<span class="label" id="detaillabelprivb6">Private Key Base6 Format (99 or more characters [0-5]):</span>
 						<span class="output" id="detailprivb6"></span>
 					</div>
 					<div class="item" style="display: none;" id="detailbip38">
@@ -471,7 +471,7 @@
 							<span id="detaillabelq1">How do I make a wallet using dice? What is B6?</span>
 							<div id="detaile1" class="more"></div>
 						</div>
-						<div id="detaila1" class="answer">An important part of creating a Bitcoin wallet is ensuring the random numbers used to create the wallet are truly random. Physical randomness is better than computer generated pseudo-randomness. The easiest way to generate physical randomness is with dice. To create a Bitcoin private key you only need one six sided die which you roll 99 times. Stopping each time to record the value of the die. When recording the values follow these rules: 1=1, 2=2, 3=3, 4=4, 5=5, 6=0. By doing this you are recording the big random number, your private key, in B6 or base 6 format. You can then enter the 99 character base 6 private key into the text field above and click View Details. You will then see the Bitcoin address associated with your private key. You should also make note of your private key in WIF format since it is more widely used.</div>
+						<div id="detaila1" class="answer">An important part of creating a Bitcoin wallet is ensuring the random numbers used to create the wallet are truly random. Physical randomness is better than computer generated pseudo-randomness. The easiest way to generate physical randomness is with dice. To create a Bitcoin private key you only need one six sided die which you roll 99 or more times. Stopping each time to record the value of the die. Each 6 will automatically be replaced by a 0. By doing this you are recording the big random number, your private key, in B6 or base 6 format. You can then enter the base 6 private key into the text field above and click View Details. You will then see the Bitcoin address associated with your private key. You should also make note of your private key in WIF format since it is more widely used.</div>
 					</div>
 				</div>
 			</div>

--- a/src/bitcoinjs-lib.eckey.js
+++ b/src/bitcoinjs-lib.eckey.js
@@ -104,7 +104,7 @@ Bitcoin.ECKey = (function () {
 			}
 			
 			if (ECKey.isBase6Format(input)) {
-				this.priv = new BigInteger(input, 6);
+				this.priv = new BigInteger(input.replace(/6/g, '0'), 6).and(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));
 			} else if (bytes == null || bytes.length != 32) {
 				this.priv = null;
 			} else {
@@ -325,10 +325,10 @@ Bitcoin.ECKey = (function () {
 		return (/^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789=+\/]{44}$/.test(key));
 	};
 
-	// 99 characters, 1=1, if using dice convert 6 to 0
+	// 99 or more characters, 1=1, if using dice convert 6 to 0
 	ECKey.isBase6Format = function (key) {
 		key = key.toString();
-		return (/^[012345]{99}$/.test(key));
+		return (/^[0-6]{99,}$/.test(key));
 	};
 
 	// 22, 26 or 30 characters, always starts with an 'S'

--- a/src/ninja.detailwallet.js
+++ b/src/ninja.detailwallet.js
@@ -43,7 +43,7 @@
 		checkAndShowBase6: function (key) {
 			if (Bitcoin.ECKey.isBase6Format(key)) {
 				// show Private Key Base6 Format
-				document.getElementById("detailprivb6").innerHTML = key;
+				document.getElementById("detailprivb6").innerHTML = key.replace(/6/g, '0');
 				document.getElementById("detailb6").style.display = "block";
 			}
 		},


### PR DESCRIPTION
Changes to the base 6 dice privkey generation:
- Allow more than 99 dice to be rolled
- Use privkey%256 as the private key.
- Replace '6' by '0' in the entered string, so the user doesn't have to.
