### PR TITLE
Create the "Bulk CSV Download" function for the Bulk Wallet

### DIFF
--- a/bitaddress.org.html
+++ b/bitaddress.org.html
@@ -6708,6 +6708,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 						<span><label id="bulklabelcompressed" for="bulkcompressed">Compressed addresses?</label> <input type="checkbox" id="bulkcompressed" checked="checked" /></span>
 						<span><input type="button" id="bulkgenerate" value="Generate" onclick="ninja.wallets.bulkwallet.buildCSV(document.getElementById('bulklimit').value * 1, document.getElementById('bulkstartindex').value * 1, document.getElementById('bulkcompressed').checked, document.getElementById('bulkpassphrase').value);" /> </span>
 						<span class="print"><input type="button" name="print" id="bulkprint" value="Print" onclick="window.print();" /></span>
+						<span><input type="button" name="download" id="bulkdownload" value="Download" onclick="ninja.wallets.bulkwallet.download();" /></span>						
 					</div>
 					<div id="bulkadvancedcommands" class="row extra">
 						<span><label id="bulklabelencrypt" for="bulkencrypt">BIP38 Encrypt?</label> <input type="checkbox" id="bulkencrypt" onchange="ninja.wallets.bulkwallet.toggleEncrypt(this);" /></span>
@@ -10047,6 +10048,24 @@ ninja.wallets.paperwallet = {
 
 		close: function () {
 			document.getElementById("bulkarea").style.display = "none";
+		},
+
+		// use this function to download the bulk generated addresses
+		// parametrs:
+		// returns:
+		// save the generated addresses as the format of (index,bitcoinAddress,privateKeyWif)
+		// save as file name "BitcoinKeys.csv"
+		download: function () {
+			let csvContent = "data:text/csv;charset=utf-8,";
+			csvContent += document.getElementById("bulktextarea").value;
+
+			var encodedUri = encodeURI(csvContent);
+			var link = document.createElement("a");
+			link.setAttribute("href", encodedUri);
+			link.setAttribute("download", "BitcoinKeys.csv");
+			document.body.appendChild(link);
+
+			link.click();
 		},
 
 		// use this function to bulk generate addresses


### PR DESCRIPTION
This pull request creates the "bulk csv download" function by adding an additional "Download" button to the Bulk Wallet section. It helps the user directly download all the generated wallet addresses by a single click. The original "Print" button does not work for addresses more than index 20. People might think copy pasting still too troublesome as well.

If you are interested, you are welcome to check out my Medium post on [this](https://medium.com/@jj1385jeff850527/generate-and-download-thousands-of-bitcoin-wallets-in-a-minute-or-two-d42ce73d77d8) (written yesterday). 

Thanks. :)